### PR TITLE
feat: Add logos and fix squeeze logic

### DIFF
--- a/BBSqueeze.py
+++ b/BBSqueeze.py
@@ -1,30 +1,15 @@
 from time import sleep
 from datetime import datetime
-from tradingview_screener import Query, col, And,Or
-# Set display options to prevent column wrapping
+from tradingview_screener import Query, col, And, Or
 import pandas as pd
 pd.set_option('display.expand_frame_repr', False)
 pd.set_option('display.max_columns', None)
-pd.set_option('display.width', 0) # Adjust as needed, 0 will use the full available width
+pd.set_option('display.width', 0)
 
-from colorama import Fore, Back, Style
 import urllib.parse
-
-
-
-from collections import defaultdict
-import csv
-
-
-import pandas as pd
-import numpy as np
-
-
-master_combined =  pd.DataFrame()
-
-import pandas as pd
 import os
 import json
+import numpy as np
 
 def append_df_to_csv(df, csv_path):
     if not os.path.exists(csv_path):
@@ -34,285 +19,124 @@ def append_df_to_csv(df, csv_path):
 
 def generate_heatmap_json(df, output_path='treemap_data.json'):
     """
-    Generates a hierarchical JSON file from the DataFrame for the D3 heatmap.
+    Generates a simple, flat JSON array of stock data for the D3 heatmap.
     """
-    # Ensure required columns exist
-    required_cols = ['ticker', 'HeatmapScore', 'TotalSqueezeFiredCount', 'Momentum', 'rvol', 'URL']
-    if not all(col in df.columns for col in required_cols):
-        print("⚠️ Cannot generate JSON. DataFrame is missing one or more required columns.")
-        return
+    # Ensure required columns exist for JSON generation
+    required_cols = ['ticker', 'HeatmapScore', 'SqueezeCount', 'rvol', 'URL', 'logo']
+    for col in required_cols:
+        if col not in df.columns:
+            # Provide a default value if a column is missing
+            df[col] = 0 if 'Score' in col or 'Count' in col or 'rvol' in col else ''
 
-    # Create the hierarchical structure
-    heatmap_data = {"name": "Squeeze Stocks", "children": []}
-
-    # Group by momentum
-    grouped = df.groupby('Momentum')
-
-    momentum_map = {
-        'Bullish': 'Bullish Momentum',
-        'Bearish': 'Bearish Momentum',
-        'Neutral': 'Neutral / Cross'
-    }
-
-    for group_name, group_df in grouped:
-        if group_name not in momentum_map:
-            continue
-
-        group_dict = {
-            "name": momentum_map[group_name],
-            "children": []
-        }
-
-        for _, row in group_df.iterrows():
-            group_dict["children"].append({
-                "name": row['ticker'],
-                "value": row['HeatmapScore'],
-                "count": row['TotalSqueezeFiredCount'],
-                "momentum": row['Momentum'], # This might be redundant but good for debugging
-                "rvol": row['rvol'],
-                "url": row['URL']
-            })
-
-        heatmap_data["children"].append(group_dict)
+    # Create a flat list of stock data
+    heatmap_data = []
+    for _, row in df.iterrows():
+        heatmap_data.append({
+            "name": row['ticker'],
+            "value": row['HeatmapScore'],
+            "count": row['SqueezeCount'],
+            "rvol": row['rvol'],
+            "url": row['URL'],
+            "logo": row['logo']
+        })
 
     # Write the JSON file
     with open(output_path, 'w') as f:
         json.dump(heatmap_data, f, indent=4)
-    print(f"✅ Heatmap JSON successfully generated at '{output_path}'.")
+    print(f"✅ Flat JSON successfully generated at '{output_path}'.")
 
+# Timeframes to check for a squeeze
+timeframes = ['', '|1', '|5', '|15', '|30', '|60', '|120', '|240', '|1W', '|1M']
 
-def identify_squeeze_fired_across_timeframes(df):
-    """
-    Identifies when a "squeeze has fired" across all available timeframes and determines
-    the breakout momentum.
+# Construct select columns for all timeframes
+select_cols = [
+    'name', 'logoid', 'close', 'volume|5', 'Value.Traded|5', 'average_volume_10d_calc|5'
+]
+for tf in timeframes:
+    select_cols.extend([f'KltChnl.lower{tf}', f'KltChnl.upper{tf}', f'BB.lower{tf}', f'BB.upper{tf}'])
 
-    A squeeze has FIRED if:
-    - The PREVIOUS candle was in a squeeze.
-    - The CURRENT candle is NOT in a squeeze.
-
-    Momentum is determined by the price relative to the Bollinger Bands on the timeframe
-    where the squeeze fired.
-
-    Args:
-        df (pd.DataFrame): DataFrame with current and previous indicator values.
-
-    Returns:
-        pd.DataFrame: The DataFrame with analysis columns including 'Momentum'.
-    """
-    timeframes = [''] + ['1', '5', '15', '30', '60', '120', '240', '1W', '1M']
-
-    if not all(c in df.columns for c in ['KltChnl.upper', 'BB.upper', 'KltChnl.upper[1]', 'BB.upper[1]', 'close']):
-        print("Warning: Missing core columns for squeeze and momentum logic.")
-        return df
-
-    print(f"--- Identifying Squeeze Fired and Momentum for {len(timeframes)} Timeframes ---")
-
-    squeeze_fired_cols = []
-    bullish_breakout_cols = []
-    bearish_breakout_cols = []
-
-    for tf in timeframes:
-        suffix = f"|{tf}" if tf else ""
-
-        # Define columns for CURRENT and PREVIOUS candles
-        kc_upper_curr, kc_lower_curr = f'KltChnl.upper{suffix}', f'KltChnl.lower{suffix}'
-        bb_upper_curr, bb_lower_curr = f'BB.upper{suffix}', f'BB.lower{suffix}'
-        kc_upper_prev, kc_lower_prev = f'KltChnl.upper{suffix}[1]', f'KltChnl.lower{suffix}[1]'
-        bb_upper_prev, bb_lower_prev = f'BB.upper{suffix}[1]', f'BB.lower{suffix}[1]'
-
-        # Column names for new signals
-        squeeze_fired_col = f'SqueezeFired{suffix}'
-        bullish_col = f'Bullish_Breakout{suffix}'
-        bearish_col = f'Bearish_Breakout{suffix}'
-
-        required = [
-            kc_upper_curr, kc_lower_curr, bb_upper_curr, bb_lower_curr,
-            kc_upper_prev, kc_lower_prev, bb_upper_prev, bb_lower_prev
-        ]
-
-        if all(c in df.columns for c in required):
-            # Squeeze state for PREVIOUS candle
-            squeeze_prev = (df[kc_upper_prev] < df[bb_upper_prev]) & (df[kc_lower_prev] > df[bb_lower_prev])
-            # Squeeze state for CURRENT candle
-            squeeze_curr = (df[kc_upper_curr] < df[bb_upper_curr]) & (df[kc_lower_curr] > df[bb_lower_curr])
-
-            # Identify if the squeeze has FIRED
-            df[squeeze_fired_col] = (squeeze_prev == True) & (squeeze_curr == False)
-            squeeze_fired_cols.append(squeeze_fired_col)
-
-            # Determine breakout direction for this timeframe
-            df[bullish_col] = df[squeeze_fired_col] & (df['close'] > df[bb_upper_curr])
-            df[bearish_col] = df[squeeze_fired_col] & (df['close'] < df[bb_lower_curr])
-            bullish_breakout_cols.append(bullish_col)
-            bearish_breakout_cols.append(bearish_col)
-
-            print(f"✅ Processed Squeeze Fired and Momentum for TF '{tf}'.")
-        else:
-            print(f"⚠️ Skipping TF '{tf}': Missing one or more required columns.")
-
-    # Calculate total fired squeezes
-    if squeeze_fired_cols:
-        df['TotalSqueezeFiredCount'] = df[squeeze_fired_cols].sum(axis=1)
-        print("✅ TotalSqueezeFiredCount column added.")
-
-    # Determine overall momentum
-    if bullish_breakout_cols and bearish_breakout_cols:
-        is_any_bullish = df[bullish_breakout_cols].any(axis=1)
-        is_any_bearish = df[bearish_breakout_cols].any(axis=1)
-
-        conditions = [is_any_bullish, is_any_bearish]
-        choices = ['Bullish', 'Bearish']
-        df['Momentum'] = np.select(conditions, choices, default='Neutral')
-        print("✅ Momentum column added.")
-
-    print("--- Processing Complete ---")
-    return df
-
-
-HIGH_VALUE = 50000000.00
-VOLUME_MULTIPLIER =  5.0
-writeHeader=True
-while True :
-    query = Query().select(
-        'name',                    # Stock name
-        'close',                   # Current price
-        'volume|5',                # 1-minute volume
-        'Value.Traded|5',          # 1-minute traded value
-        'average_volume_10d_calc', # Average volume (10 days)
-        'average_volume_10d_calc|5', # Average 1-minute volume (10 days)
-        # Keltner Channel (Current and Previous)
-        'KltChnl.lower', 'KltChnl.lower[1]',
-        'KltChnl.lower|1', 'KltChnl.lower|1[1]',
-        'KltChnl.lower|5', 'KltChnl.lower|5[1]',
-        'KltChnl.lower|15', 'KltChnl.lower|15[1]',
-        'KltChnl.lower|30', 'KltChnl.lower|30[1]',
-        'KltChnl.lower|60', 'KltChnl.lower|60[1]',
-        'KltChnl.lower|120', 'KltChnl.lower|120[1]',
-        'KltChnl.lower|240', 'KltChnl.lower|240[1]',
-        'KltChnl.lower|1W', 'KltChnl.lower|1W[1]',
-        'KltChnl.lower|1M', 'KltChnl.lower|1M[1]',
-        'KltChnl.upper', 'KltChnl.upper[1]',
-        'KltChnl.upper|1', 'KltChnl.upper|1[1]',
-        'KltChnl.upper|5', 'KltChnl.upper|5[1]',
-        'KltChnl.upper|15', 'KltChnl.upper|15[1]',
-        'KltChnl.upper|30', 'KltChnl.upper|30[1]',
-        'KltChnl.upper|60', 'KltChnl.upper|60[1]',
-        'KltChnl.upper|120', 'KltChnl.upper|120[1]',
-        'KltChnl.upper|240', 'KltChnl.upper|240[1]',
-        'KltChnl.upper|1W', 'KltChnl.upper|1W[1]',
-        'KltChnl.upper|1M', 'KltChnl.upper|1M[1]',
-        # Bollinger Bands (Current and Previous)
-        'BB.lower', 'BB.lower[1]',
-        'BB.lower|1', 'BB.lower|1[1]',
-        'BB.lower|5', 'BB.lower|5[1]',
-        'BB.lower|15', 'BB.lower|15[1]',
-        'BB.lower|30', 'BB.lower|30[1]',
-        'BB.lower|60', 'BB.lower|60[1]',
-        'BB.lower|120', 'BB.lower|120[1]',
-        'BB.lower|240', 'BB.lower|240[1]',
-        'BB.lower|1W', 'BB.lower|1W[1]',
-        'BB.lower|1M', 'BB.lower|1M[1]',
-        'BB.upper', 'BB.upper[1]',
-        'BB.upper|1', 'BB.upper|1[1]',
-        'BB.upper|5', 'BB.upper|5[1]',
-        'BB.upper|15', 'BB.upper|15[1]',
-        'BB.upper|30', 'BB.upper|30[1]',
-        'BB.upper|60', 'BB.upper|60[1]',
-        'BB.upper|120', 'BB.upper|120[1]',
-        'BB.upper|240', 'BB.upper|240[1]',
-        'BB.upper|1W', 'BB.upper|1W[1]',
-        'BB.upper|1M', 'BB.upper|1M[1]'
-    ).where2(
-        And(
-            col('is_primary') == True,
-            col('typespecs').has('common'),
-            col('type') == 'stock',
-            col('exchange') == 'NSE',
-            col('close').between(20, 10000),
-            col('active_symbol') == True,
-            col('average_volume_10d_calc|5') > 50000,
-            col('Value.Traded|5') > 10000000,
-
-        # Filter for stocks that were in a squeeze on the PREVIOUS candle on any timeframe
-        Or(
-            And(col('BB.upper[1]') < col('KltChnl.upper[1]'),
-                col('BB.lower[1]') > col('KltChnl.lower[1]')),
-            And(col('BB.upper|1[1]') < col('KltChnl.upper|1[1]'),
-                col('BB.lower|1[1]') > col('KltChnl.lower|1[1]')),
-            And(col('BB.upper|5[1]') < col('KltChnl.upper|5[1]'),
-                col('BB.lower|5[1]') > col('KltChnl.lower|5[1]')),
-            And(col('BB.upper|15[1]') < col('KltChnl.upper|15[1]'),
-                col('BB.lower|15[1]') > col('KltChnl.lower|15[1]')),
-            And(col('BB.upper|30[1]') < col('KltChnl.upper|30[1]'),
-                col('BB.lower|30[1]') > col('KltChnl.lower|30[1]')),
-            And(col('BB.upper|60[1]') < col('KltChnl.upper|60[1]'),
-                col('BB.lower|60[1]') > col('KltChnl.lower|60[1]')),
-            And(col('BB.upper|120[1]') < col('KltChnl.upper|120[1]'),
-                col('BB.lower|120[1]') > col('KltChnl.lower|120[1]')),
-            And(col('BB.upper|240[1]') < col('KltChnl.upper|240[1]'),
-                col('BB.lower|240[1]') > col('KltChnl.lower|240[1]')),
-            And(col('BB.upper|1W[1]') < col('KltChnl.upper|1W[1]'),
-                col('BB.lower|1W[1]') > col('KltChnl.lower|1W[1]')),
-            And(col('BB.upper|1M[1]') < col('KltChnl.upper|1M[1]'),
-                col('BB.lower|1M[1]') > col('KltChnl.lower|1M[1]')),
+while True:
+    try:
+        # Construct the 'where' condition for current squeezes
+        squeeze_conditions = []
+        for tf in timeframes:
+            squeeze_conditions.append(
+                And(
+                    col(f'BB.upper{tf}') < col(f'KltChnl.upper{tf}'),
+                    col(f'BB.lower{tf}') > col(f'KltChnl.lower{tf}')
+                )
             )
-        )
 
-    ).order_by(
-        'volume|1', ascending=False
-    ).limit(200).set_markets('india').set_property(
-        'preset', 'all_stocks'
-    ).set_property(
-        'symbols', {'query': {'types': ['stock', 'fund', 'dr']}}
-    )
-    # Execute the query
-    _, dfNew = query.get_scanner_data()
+        query = Query().select(
+            *select_cols
+        ).where2(
+            And(
+                col('is_primary') == True,
+                col('typespecs').has('common'),
+                col('type') == 'stock',
+                col('exchange') == 'NSE',
+                col('close').between(20, 10000),
+                col('active_symbol') == True,
+                col('average_volume_10d_calc|5') > 50000,
+                col('Value.Traded|5') > 10000000,
+                Or(*squeeze_conditions) # Filter for stocks currently in a squeeze on any timeframe
+            )
+        ).order_by(
+            'volume|5', ascending=False
+        ).limit(200).set_markets('india')
 
-    if not dfNew.empty :
-        current_time = datetime.now().strftime('%H:%M:%S')
-        current_DATE = datetime.now().strftime('%d_%m_%y')
+        # Execute the query
+        _, dfNew = query.get_scanner_data()
 
-        dfNew.insert(3, 'URL',"")
-        dfNew['encodedTicker'] = dfNew['ticker'].apply(urllib.parse.quote)
-        dfNew['URL'] = "https://in.tradingview.com/chart/N8zfIJVK/?symbol="+dfNew['encodedTicker']+" "
-        dfNew.insert(0, 'current_timestamp', current_time)
+        if dfNew is not None and not dfNew.empty:
+            current_time = datetime.now().strftime('%H:%M:%S')
+            current_DATE = datetime.now().strftime('%d_%m_%y')
 
-        # Identify which stocks have a fired squeeze
-        processed_df = identify_squeeze_fired_across_timeframes(dfNew)
+            # --- Post-processing ---
 
-        # Calculate RVOL and Heatmap Score for visualization
-        if 'average_volume_10d_calc|5' in processed_df.columns and 'volume|5' in processed_df.columns:
-            # Replace 0s or NaNs in the denominator to avoid division by zero errors
-            avg_vol = processed_df['average_volume_10d_calc|5'].replace(0, np.nan)
-            processed_df['rvol'] = processed_df['volume|5'] / avg_vol
-            processed_df['rvol'] = processed_df['rvol'].fillna(0)  # Fill any NaNs that result from division
+            # Add URL
+            dfNew['encodedTicker'] = dfNew['ticker'].apply(urllib.parse.quote)
+            dfNew['URL'] = "https://in.tradingview.com/chart/N8zfIJVK/?symbol=" + dfNew['encodedTicker']
+            dfNew.insert(0, 'current_timestamp', current_time)
 
-            # Calculate Heatmap Score, ensuring TotalSqueezeFiredCount exists
-            if 'TotalSqueezeFiredCount' in processed_df.columns:
-                processed_df['HeatmapScore'] = (processed_df['rvol'] + 1) * processed_df['TotalSqueezeFiredCount']
-                print("✅ RVOL and HeatmapScore columns added.")
+            # Add logo URL
+            if 'logoid' in dfNew.columns:
+                dfNew['logo'] = dfNew['logoid'].apply(lambda x: f"https://s3-symbol-logo.tradingview.com/{x}.svg" if pd.notna(x) and x.strip() else '')
             else:
-                processed_df['HeatmapScore'] = 0
-                print("⚠️ TotalSqueezeFiredCount column not found. HeatmapScore set to 0.")
+                dfNew['logo'] = ''
 
-        else:
-            print("⚠️ Could not calculate RVOL or HeatmapScore: Volume columns are missing.")
-            processed_df['rvol'] = 0
-            processed_df['HeatmapScore'] = 0
+            # Calculate how many timeframes the stock is in a squeeze
+            squeeze_count_cols = []
+            for tf in timeframes:
+                col_name = f'InSqueeze{tf}'
+                dfNew[col_name] = (dfNew[f'BB.upper{tf}'] < dfNew[f'KltChnl.upper{tf}']) & \
+                                  (dfNew[f'BB.lower{tf}'] > dfNew[f'KltChnl.lower{tf}'])
+                squeeze_count_cols.append(col_name)
 
-        # Filter for stocks that have at least one fired squeeze
-        filtered_df = processed_df[processed_df['TotalSqueezeFiredCount'] > 0]
+            dfNew['SqueezeCount'] = dfNew[squeeze_count_cols].sum(axis=1)
 
-        if not filtered_df.empty :
-            # Generate the JSON for the heatmap visualization
-            generate_heatmap_json(filtered_df)
+            # Calculate RVOL
+            if 'average_volume_10d_calc|5' in dfNew.columns and 'volume|5' in dfNew.columns:
+                avg_vol = dfNew['average_volume_10d_calc|5'].replace(0, np.nan)
+                dfNew['rvol'] = dfNew['volume|5'] / avg_vol
+                dfNew['rvol'] = dfNew['rvol'].fillna(0)
+            else:
+                dfNew['rvol'] = 0
 
-            # (Optional) Save the detailed CSV report as well
-            append_df_to_csv(filtered_df, 'BBSCAN_FIRED_'+str(current_DATE)+'.csv')
+            # Calculate Heatmap Score
+            dfNew['HeatmapScore'] = (dfNew['rvol'] + 1) * dfNew['SqueezeCount']
+
+            # Generate the JSON for the heatmap
+            generate_heatmap_json(dfNew)
+
+            # Save detailed report
+            append_df_to_csv(dfNew, 'BBSCAN_IN_SQUEEZE_'+str(current_DATE)+'.csv')
 
             print(f"=="*30)
-            writeHeader=False
-            print("--- Filtered Results ---")
-            print(filtered_df[['ticker', 'Momentum', 'TotalSqueezeFiredCount', 'rvol', 'HeatmapScore']])
+            print("--- Squeeze Results ---")
+            print(dfNew[['ticker', 'SqueezeCount', 'rvol', 'HeatmapScore', 'logo']])
+
+    except Exception as e:
+        print(f"An error occurred: {e}")
 
     sleep(120)

--- a/SqueezeHeatmap.html
+++ b/SqueezeHeatmap.html
@@ -7,54 +7,62 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
-        body { font-family: sans-serif; }
+        body { font-family: sans-serif; background-color: #111827; color: white; }
         .chart-container {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
-            gap: 4px;
-            padding: 10px;
+            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+            gap: 8px;
+            padding: 16px;
         }
         .cell {
             display: flex;
             flex-direction: column;
-            justify-content: center;
+            justify-content: space-between;
             align-items: center;
-            color: white;
-            padding: 8px;
-            border-radius: 4px;
+            padding: 10px;
+            border-radius: 6px;
             cursor: pointer;
             text-align: center;
-            height: 80px;
-            transition: transform 0.2s;
+            height: 110px;
+            transition: transform 0.2s, background-color 0.2s;
+            border: 1px solid #374151;
         }
         .cell:hover {
             transform: scale(1.05);
+            border-color: #9ca3af;
+        }
+        .stock-logo {
+            width: 36px;
+            height: 36px;
+            margin-bottom: 6px;
+            border-radius: 50%;
+            background-color: #374151;
         }
         .stock-ticker {
-            font-weight: bold;
+            font-weight: 600;
             font-size: 14px;
         }
-        .stock-rvol {
-            font-size: 12px;
+        .stock-info {
+            font-size: 11px;
+            color: #d1d5db;
         }
         .tooltip {
             position: absolute;
             text-align: center;
-            width: auto;
-            height: auto;
             padding: 8px;
             font: 12px sans-serif;
-            background: lightsteelblue;
-            border: 0px;
+            background: #1f2937;
+            border: 1px solid #4b5563;
             border-radius: 8px;
             pointer-events: none;
             opacity: 0;
+            color: white;
         }
     </style>
 </head>
-<body class="bg-gray-100">
+<body class="bg-gray-900">
     <div class="container mx-auto p-4">
-        <h1 class="text-2xl font-bold text-center mb-4">Stock Squeeze Heatmap</h1>
+        <h1 class="text-3xl font-bold text-center mb-6">Stocks Currently in a Squeeze</h1>
         <div id="chart" class="chart-container"></div>
         <div class="tooltip"></div>
     </div>
@@ -63,90 +71,72 @@
         const chartContainer = d3.select("#chart");
         const tooltip = d3.select(".tooltip");
 
-        function getMomentumGroup(stock) {
-            // Get the group name from the parent node in the D3 hierarchy. This is more reliable
-            // than inspecting a property on the leaf node itself.
-            const parentName = stock.parent.data.name;
-            if (parentName === 'Bullish Momentum') return 'Bullish';
-            if (parentName === 'Bearish Momentum') return 'Bearish';
-            return 'Neutral';
-        }
-
         async function loadData() {
-            // Append a cache-busting query parameter to ensure fresh data
-            const data = await d3.json(`treemap_data.json?t=${new Date().getTime()}`);
+            try {
+                const data = await d3.json(`treemap_data.json?t=${new Date().getTime()}`);
 
-            // The data is hierarchical. We need to flatten it into a list of all stocks (leaves).
-            const root = d3.hierarchy(data).sum(d => d.value);
-            const leaves = root.leaves();
+                // Sort data by HeatmapScore (value)
+                data.sort((a, b) => b.value - a.value);
 
-            // Sort leaves by group to cluster them visually
-            leaves.sort((a, b) => {
-                const groupA = getMomentumGroup(a);
-                const groupB = getMomentumGroup(b);
-                if (groupA < groupB) return -1;
-                if (groupA > groupB) return 1;
-                return b.data.value - a.data.value; // Secondary sort by heatmap value
-            });
+                // Define a single color scale based on RVOL
+                // Using a green scale, as "in a squeeze" is a state of interest
+                const colorScale = d3.scaleLinear()
+                    .domain([0, 5]) // RVOL typically ranges from 0 to 5+
+                    .range(["#166534", "#22c55e"]) // Dark green to bright green
+                    .clamp(true);
 
-            // Define color scales. We'll map RVOL (0 to ~5) to a color intensity.
-            const colorScales = {
-                Bullish: d3.scaleLinear().domain([0, 5]).range(["#1a472a", "#48bb78"]), // Dark to light green
-                Bearish: d3.scaleLinear().domain([0, 5]).range(["#7f1d1d", "#f56565"]), // Dark to light red
-                Neutral: d3.scaleLinear().domain([0, 5]).range(["#4a5568", "#a0aec0"])  // Dark to light gray
-            };
+                // --- D3 Data Binding ---
+                const cells = chartContainer.selectAll(".cell")
+                    .data(data, d => d.name);
 
-            // --- D3 Data Binding ---
-            const cells = chartContainer.selectAll(".cell")
-                .data(leaves, d => d.data.name); // Key function for object constancy
+                // Exit selection
+                cells.exit().remove();
 
-            // Exit selection: Remove cells that are no longer in the data
-            cells.exit().remove();
+                // Enter selection
+                const enterCells = cells.enter()
+                    .append("div")
+                    .attr("class", "cell")
+                    .on("click", (event, d) => window.open(d.url, "_blank"))
+                    .on("mouseover", function(event, d) {
+                        tooltip.transition().duration(200).style("opacity", .9);
+                        tooltip.html(
+                            `<strong>${d.name.replace('NSE:', '')}</strong><br/>` +
+                            `Squeeze on ${d.count} timeframes<br/>` +
+                            `RVOL: ${d.rvol.toFixed(2)}<br/>` +
+                            `Score: ${d.value.toFixed(2)}`
+                        )
+                        .style("left", (event.pageX + 10) + "px")
+                        .style("top", (event.pageY - 28) + "px");
+                    })
+                    .on("mouseout", function(d) {
+                        tooltip.transition().duration(500).style("opacity", 0);
+                    });
 
-            // Enter selection: Create new div elements for new stocks
-            const enterCells = cells.enter()
-                .append("div")
-                .attr("class", "cell")
-                .on("click", (event, d) => window.open(d.data.url, "_blank"))
-                .on("mouseover", function(event, d) {
-                    tooltip.transition().duration(200).style("opacity", .9);
-                    tooltip.html(
-                        `<strong>${d.data.name}</strong><br/>` +
-                        `Squeeze Count: ${d.data.count}<br/>` +
-                        `RVOL: ${d.data.rvol.toFixed(2)}<br/>` +
-                        `Heatmap Score: ${d.data.value.toFixed(2)}`
-                    )
-                    .style("left", (event.pageX + 10) + "px")
-                    .style("top", (event.pageY - 28) + "px");
-                })
-                .on("mouseout", function(d) {
-                    tooltip.transition().duration(500).style("opacity", 0);
-                });
+                enterCells.append("img").attr("class", "stock-logo");
+                enterCells.append("div").attr("class", "stock-ticker");
+                enterCells.append("div").attr("class", "stock-info");
 
-            // Add child elements for the text within each cell
-            enterCells.append("div").attr("class", "stock-ticker");
-            enterCells.append("div").attr("class", "stock-rvol");
+                // Merge enter and update selections
+                const updateCells = enterCells.merge(cells);
 
-            // Merge enter and update selections to apply updates to all existing cells
-            const updateCells = enterCells.merge(cells);
+                // Update all cells
+                updateCells.style("background-color", d => colorScale(d.rvol));
 
-            // Update styling and text for all cells (both new and existing)
-            updateCells
-                .style("background-color", d => {
-                    const group = getMomentumGroup(d);
-                    // Clamp RVOL to the domain max to prevent invalid colors
-                    const rvol = Math.min(d.data.rvol, 5);
-                    return colorScales[group](rvol);
-                });
+                updateCells.select(".stock-logo")
+                    .attr("src", d => d.logo)
+                    .style("display", d => d.logo ? 'block' : 'none');
 
-            updateCells.select(".stock-ticker").text(d => d.data.name.replace('NSE:', ''));
-            updateCells.select(".stock-rvol").text(d => `RVOL: ${d.data.rvol.toFixed(2)}`);
+                updateCells.select(".stock-ticker").text(d => d.name.replace('NSE:', ''));
+                updateCells.select(".stock-info").text(d => `RVOL: ${d.rvol.toFixed(2)}`);
+
+            } catch (error) {
+                console.error("Failed to load or process data:", error);
+                chartContainer.html("<p class='text-center text-red-500'>Failed to load data. Please check the console.</p>");
+            }
         }
 
-        // Initial data load
+        // Initial data load and interval
         loadData();
-
-        // Set an interval to auto-refresh the data every 2 minutes (120,000 ms)
         setInterval(loadData, 120000);
     </script>
 </body>


### PR DESCRIPTION
This commit refactors the application to correctly identify stocks currently in a squeeze and adds company logos to the heatmap visualization.

- **BBSqueeze.py:**
  - Corrected the core logic by removing all dependencies on previous candle data (`[1]`), which is not provided by the scanner.
  - The query now filters for stocks that are *currently* in a squeeze (Bollinger Bands inside Keltner Channels) on any of the specified timeframes.
  - The `identify_squeeze_fired_across_timeframes` function was removed and replaced with inline logic to count the number of timeframes a stock is in a squeeze.
  - Added fetching of `logoid` and construction of the logo URL.
  - The `generate_heatmap_json` function was simplified to produce a flat JSON array.

- **SqueezeHeatmap.html:**
  - The UI and D3.js script were updated to consume the new flat JSON structure.
  - The heatmap now displays a single group of stocks currently in a squeeze.
  - Cell coloring is now based on RVOL.
  - The company logo is now displayed in each cell.