### PR TITLE
feat: Add toggle for 'In Squeeze' and 'Squeeze Fired' views

### DIFF
--- a/BBSqueeze.py
+++ b/BBSqueeze.py
@@ -1,24 +1,20 @@
 import os
 import urllib.parse
-import json # New import for JSON handling
+import json
 from time import sleep
 from datetime import datetime
-
+import numpy as np
 from tradingview_screener import Query, col, And, Or
 import pandas as pd
+
 pd.set_option('display.expand_frame_repr', False)
 pd.set_option('display.max_columns', None)
 pd.set_option('display.width', 0)
 
-import urllib.parse
-import os
-import json
-import numpy as np
-
 
 def append_df_to_csv(df, csv_path):
     """
-    Appends a DataFrame to a CSV file. Creates the file with a header if it doesn't 
+    Appends a DataFrame to a CSV file. Creates the file with a header if it doesn't
     exist, otherwise appends without the header.
     """
     if not os.path.exists(csv_path):
@@ -26,19 +22,32 @@ def append_df_to_csv(df, csv_path):
     else:
         df.to_csv(csv_path, mode='a', header=False, index=False)
 
-# --- Momentum Logic Function ---
 
 def get_momentum_indicator(macd_hist_value):
     """
+    Determines momentum based on the MACD histogram value.
+    """
+    if macd_hist_value > 0:
+        return 'Bullish'
+    elif macd_hist_value < 0:
+        return 'Bearish'
+    else:
+        return 'Neutral'
 
+
+def generate_heatmap_json(df, output_path):
+    """
     Generates a simple, flat JSON array of stock data for the D3 heatmap.
     """
     # Ensure required columns exist for JSON generation
-    required_cols = ['ticker', 'HeatmapScore', 'SqueezeCount', 'rvol', 'URL', 'logo']
-    for col in required_cols:
-        if col not in df.columns:
+    required_cols = ['ticker', 'HeatmapScore', 'SqueezeCount', 'rvol', 'URL', 'logo', 'momentum']
+    for c in required_cols:
+        if c not in df.columns:
             # Provide a default value if a column is missing
-            df[col] = 0 if 'Score' in col or 'Count' in col or 'rvol' in col else ''
+            if c == 'momentum':
+                df[c] = 'Neutral'
+            else:
+                df[c] = 0 if 'Score' in c or 'Count' in c or 'rvol' in c else ''
 
     # Create a flat list of stock data
     heatmap_data = []
@@ -49,7 +58,8 @@ def get_momentum_indicator(macd_hist_value):
             "count": row['SqueezeCount'],
             "rvol": row['rvol'],
             "url": row['URL'],
-            "logo": row['logo']
+            "logo": row['logo'],
+            "momentum": row['momentum']
         })
 
     # Write the JSON file
@@ -57,100 +67,134 @@ def get_momentum_indicator(macd_hist_value):
         json.dump(heatmap_data, f, indent=4)
     print(f"✅ Flat JSON successfully generated at '{output_path}'.")
 
+
+# --- Configuration ---
+PREV_SQUEEZE_FILE = 'previous_squeeze_list.json'
+OUTPUT_JSON_FIRED = 'treemap_data_fired.json'
+OUTPUT_JSON_IN_SQUEEZE = 'treemap_data_in_squeeze.json'
+TIME_INTERVAL_SECONDS = 120
+
 # Timeframes to check for a squeeze
 timeframes = ['', '|1', '|5', '|15', '|30', '|60', '|120', '|240', '|1W', '|1M']
 
 # Construct select columns for all timeframes
 select_cols = [
-    'name', 'logoid', 'close', 'volume|5', 'Value.Traded|5', 'average_volume_10d_calc|5'
+    'name', 'logoid', 'close', 'volume|5', 'Value.Traded|5', 'average_volume_10d_calc|5', 'MACD.macd_hist'
 ]
 for tf in timeframes:
     select_cols.extend([f'KltChnl.lower{tf}', f'KltChnl.upper{tf}', f'BB.lower{tf}', f'BB.upper{tf}'])
 
+
+def load_previous_squeeze_list(filepath):
+    if os.path.exists(filepath):
+        with open(filepath, 'r') as f:
+            return json.load(f)
+    return []
+
+
+def save_current_squeeze_list(data, filepath):
+    with open(filepath, 'w') as f:
+        json.dump(data, f)
+
+
+# --- Main Loop ---
 while True:
     try:
-        # Construct the 'where' condition for current squeezes
-        squeeze_conditions = []
-        for tf in timeframes:
-            squeeze_conditions.append(
-                And(
-                    col(f'BB.upper{tf}') < col(f'KltChnl.upper{tf}'),
-                    col(f'BB.lower{tf}') > col(f'KltChnl.lower{tf}')
-                )
+        # 1. Load the list of tickers that were in a squeeze previously
+        prev_squeeze_list = load_previous_squeeze_list(PREV_SQUEEZE_FILE)
+        print(f"Loaded {len(prev_squeeze_list)} tickers from the previous scan.")
 
-            )
-
-        query = Query().select(
-            *select_cols
-        ).where2(
+        # 2. Find all stocks currently in a squeeze (fetch full data)
+        squeeze_conditions = [
             And(
-                col('is_primary') == True,
-                col('typespecs').has('common'),
-                col('type') == 'stock',
-                col('exchange') == 'NSE',
-                col('close').between(20, 10000),
-                col('active_symbol') == True,
-                col('average_volume_10d_calc|5') > 50000,
-                col('Value.Traded|5') > 10000000,
-                Or(*squeeze_conditions) # Filter for stocks currently in a squeeze on any timeframe
+                col(f'BB.upper{tf}') < col(f'KltChnl.upper{tf}'),
+                col(f'BB.lower{tf}') > col(f'KltChnl.lower{tf}')
+            ) for tf in timeframes
+        ]
+        query_in_squeeze = Query().select(*select_cols).where2(
+            And(
+                col('is_primary') == True, col('typespecs').has('common'), col('type') == 'stock',
+                col('exchange') == 'NSE', col('close').between(20, 10000), col('active_symbol') == True,
+                col('average_volume_10d_calc|5') > 50000, col('Value.Traded|5') > 10000000,
+                Or(*squeeze_conditions)
             )
-        ).order_by(
-            'volume|5', ascending=False
-        ).limit(200).set_markets('india')
+        ).limit(500).set_markets('india')
 
-        # Execute the query
-        _, dfNew = query.get_scanner_data()
+        _, df_in_squeeze = query_in_squeeze.get_scanner_data()
 
-        if dfNew is not None and not dfNew.empty:
-            current_time = datetime.now().strftime('%H:%M:%S')
-            current_DATE = datetime.now().strftime('%d_%m_%y')
+        current_squeeze_list = []
+        if df_in_squeeze is not None and not df_in_squeeze.empty:
+            print(f"Found {len(df_in_squeeze)} tickers currently in a squeeze.")
+            current_squeeze_list = df_in_squeeze['ticker'].tolist()
 
-            # --- Post-processing ---
+            # --- Process and save "In Squeeze" data ---
+            df_in_squeeze['encodedTicker'] = df_in_squeeze['ticker'].apply(urllib.parse.quote)
+            df_in_squeeze['URL'] = "https://in.tradingview.com/chart/N8zfIJVK/?symbol=" + df_in_squeeze['encodedTicker']
+            df_in_squeeze['logo'] = df_in_squeeze['logoid'].apply(
+                lambda x: f"https://s3-symbol-logo.tradingview.com/{x}.svg" if pd.notna(x) and x.strip() else '')
 
-            # Add URL
-            dfNew['encodedTicker'] = dfNew['ticker'].apply(urllib.parse.quote)
-            dfNew['URL'] = "https://in.tradingview.com/chart/N8zfIJVK/?symbol=" + dfNew['encodedTicker']
-            dfNew.insert(0, 'current_timestamp', current_time)
-
-            # Add logo URL
-            if 'logoid' in dfNew.columns:
-                dfNew['logo'] = dfNew['logoid'].apply(lambda x: f"https://s3-symbol-logo.tradingview.com/{x}.svg" if pd.notna(x) and x.strip() else '')
-            else:
-                dfNew['logo'] = ''
-
-            # Calculate how many timeframes the stock is in a squeeze
             squeeze_count_cols = []
             for tf in timeframes:
                 col_name = f'InSqueeze{tf}'
-                dfNew[col_name] = (dfNew[f'BB.upper{tf}'] < dfNew[f'KltChnl.upper{tf}']) & \
-                                  (dfNew[f'BB.lower{tf}'] > dfNew[f'KltChnl.lower{tf}'])
+                df_in_squeeze[col_name] = (df_in_squeeze[f'BB.upper{tf}'] < df_in_squeeze[f'KltChnl.upper{tf}']) & \
+                                          (df_in_squeeze[f'BB.lower{tf}'] > df_in_squeeze[f'KltChnl.lower{tf}'])
                 squeeze_count_cols.append(col_name)
+            df_in_squeeze['SqueezeCount'] = df_in_squeeze[squeeze_count_cols].sum(axis=1)
 
-            dfNew['SqueezeCount'] = dfNew[squeeze_count_cols].sum(axis=1)
+            avg_vol = df_in_squeeze['average_volume_10d_calc|5'].replace(0, np.nan)
+            df_in_squeeze['rvol'] = (df_in_squeeze['volume|5'] / avg_vol).fillna(0)
+            df_in_squeeze['HeatmapScore'] = (df_in_squeeze['rvol'] + 1) * df_in_squeeze['SqueezeCount']
+            df_in_squeeze['momentum'] = 'Neutral' # Momentum is not applicable for "in squeeze"
 
-            # Calculate RVOL
-            if 'average_volume_10d_calc|5' in dfNew.columns and 'volume|5' in dfNew.columns:
-                avg_vol = dfNew['average_volume_10d_calc|5'].replace(0, np.nan)
-                dfNew['rvol'] = dfNew['volume|5'] / avg_vol
-                dfNew['rvol'] = dfNew['rvol'].fillna(0)
+            generate_heatmap_json(df_in_squeeze, OUTPUT_JSON_IN_SQUEEZE)
+        else:
+            print("No tickers found currently in a squeeze.")
+            # Write empty JSON if no stocks are in a squeeze
+            generate_heatmap_json(pd.DataFrame(), OUTPUT_JSON_IN_SQUEEZE)
+
+        # 3. Identify and process "Squeeze Fired" stocks
+        fired_tickers = [ticker for ticker in prev_squeeze_list if ticker not in current_squeeze_list]
+        print(f"Found {len(fired_tickers)} tickers where squeeze has fired.")
+
+        if fired_tickers:
+            # We need to re-query to get the latest data at the moment of firing
+            query_fired = Query().select(*select_cols).where2(col('name').is_in(fired_tickers)).set_markets('india')
+            _, df_fired = query_fired.get_scanner_data()
+
+            if df_fired is not None and not df_fired.empty:
+                current_DATE = datetime.now().strftime('%d_%m_%y')
+                df_fired['encodedTicker'] = df_fired['ticker'].apply(urllib.parse.quote)
+                df_fired['URL'] = "https://in.tradingview.com/chart/N8zfIJVK/?symbol=" + df_fired['encodedTicker']
+                df_fired['logo'] = df_fired['logoid'].apply(
+                    lambda x: f"https://s3-symbol-logo.tradingview.com/{x}.svg" if pd.notna(x) and x.strip() else '')
+
+                # We assume it was in a squeeze on at least one timeframe.
+                df_fired['SqueezeCount'] = 1
+
+                avg_vol = df_fired['average_volume_10d_calc|5'].replace(0, np.nan)
+                df_fired['rvol'] = (df_fired['volume|5'] / avg_vol).fillna(0)
+                df_fired['momentum'] = df_fired['MACD.macd_hist'].apply(get_momentum_indicator)
+                df_fired['HeatmapScore'] = (df_fired['rvol'] + 1) * df_fired['SqueezeCount']
+
+                generate_heatmap_json(df_fired, OUTPUT_JSON_FIRED)
+                append_df_to_csv(df_fired, 'BBSCAN_FIRED_' + str(current_DATE) + '.csv')
+                print("--- Fired Squeeze Results ---")
+                print(df_fired[['ticker', 'momentum', 'SqueezeCount', 'rvol', 'HeatmapScore']])
             else:
-                dfNew['rvol'] = 0
+                # Write empty JSON if fired tickers couldn't be fetched
+                generate_heatmap_json(pd.DataFrame(), OUTPUT_JSON_FIRED)
+        else:
+            print("No squeezes fired in this interval.")
+            # Write empty JSON if no stocks have fired
+            generate_heatmap_json(pd.DataFrame(), OUTPUT_JSON_FIRED)
 
-            # Calculate Heatmap Score
-            dfNew['HeatmapScore'] = (dfNew['rvol'] + 1) * dfNew['SqueezeCount']
-
-            # Generate the JSON for the heatmap
-            generate_heatmap_json(dfNew)
-
-            # Save detailed report
-            append_df_to_csv(dfNew, 'BBSCAN_IN_SQUEEZE_'+str(current_DATE)+'.csv')
-
-            print(f"=="*30)
-            print("--- Squeeze Results ---")
-            print(dfNew[['ticker', 'SqueezeCount', 'rvol', 'HeatmapScore', 'logo']])
+        # 4. Save the current list of squeezed stocks for the next iteration
+        save_current_squeeze_list(current_squeeze_list, PREV_SQUEEZE_FILE)
+        print(f"Saved {len(current_squeeze_list)} currently squeezed tickers for the next scan.")
 
     except Exception as e:
         print(f"An error occurred: {e}")
 
-    sleep(120)
+    print(f"\n--- Waiting for {TIME_INTERVAL_SECONDS} seconds until the next scan ---\n")
+    sleep(TIME_INTERVAL_SECONDS)
 

--- a/SqueezeHeatmap.html
+++ b/SqueezeHeatmap.html
@@ -71,7 +71,12 @@
 </head>
 <body class="bg-gray-900">
     <div class="container mx-auto p-4">
-        <h1 class="text-3xl font-bold text-center mb-6">Stocks Currently in a Squeeze</h1>
+        <h1 class="text-3xl font-bold text-center mb-2">Real-Time Stock Squeeze Scanner</h1>
+        <div id="toggle-controls" class="flex justify-center my-4 space-x-2">
+            <button id="btn-fired" class="px-4 py-2 rounded-md text-sm font-medium transition">Squeeze Fired</button>
+            <button id="btn-in-squeeze" class="px-4 py-2 rounded-md text-sm font-medium transition">In Squeeze</button>
+        </div>
+        <p id="description" class="text-center text-gray-400 mb-6"></p>
         <div id="chart" class="chart-container"></div>
         <div class="tooltip"></div>
     </div>
@@ -79,43 +84,63 @@
     <script>
         const chartContainer = d3.select("#chart");
         const tooltip = d3.select(".tooltip");
+        const btnFired = document.getElementById('btn-fired');
+        const btnInSqueeze = document.getElementById('btn-in-squeeze');
+        const description = document.getElementById('description');
+
+        let currentMode = 'fired'; // 'fired' or 'in_squeeze'
+        let refreshInterval;
+
+        // --- Color Scales ---
+        const rvolDomain = [0, 5];
+        const bullishColor = d3.scaleLinear().domain(rvolDomain).range(["#064e3b", "#10b981"]).clamp(true);
+        const bearishColor = d3.scaleLinear().domain(rvolDomain).range(["#7f1d1d", "#ef4444"]).clamp(true);
+        const neutralColor = d3.scaleLinear().domain(rvolDomain).range(["#374151", "#6b7280"]).clamp(true);
+        const inSqueezeColor = d3.scaleLinear().domain(rvolDomain).range(["#166534", "#22c55e"]).clamp(true);
+
+        function getCellColor(d) {
+            if (currentMode === 'fired') {
+                if (d.momentum === 'Bullish') return bullishColor(d.rvol);
+                if (d.momentum === 'Bearish') return bearishColor(d.rvol);
+                return neutralColor(d.rvol);
+            }
+            return inSqueezeColor(d.rvol);
+        }
+
+        function getTooltipHtml(d) {
+            if (currentMode === 'fired') {
+                return `<strong>${d.name.replace('NSE:', '')}</strong><br/>` +
+                       `Momentum: <span style="color: ${getCellColor(d)};">${d.momentum}</span><br/>` +
+                       `RVOL: ${d.rvol.toFixed(2)}<br/>` +
+                       `Score: ${d.value.toFixed(2)}`;
+            }
+            return `<strong>${d.name.replace('NSE:', '')}</strong><br/>` +
+                   `Squeeze on ${d.count} timeframes<br/>` +
+                   `RVOL: ${d.rvol.toFixed(2)}<br/>` +
+                   `Score: ${d.value.toFixed(2)}`;
+        }
 
         async function loadData() {
+            const filename = currentMode === 'fired' ? 'treemap_data_fired.json' : 'treemap_data_in_squeeze.json';
             try {
-                const data = await d3.json(`treemap_data.json?t=${new Date().getTime()}`);
-
-                // Sort data by HeatmapScore (value)
+                const data = await d3.json(`${filename}?t=${new Date().getTime()}`);
                 data.sort((a, b) => b.value - a.value);
-
-                // Define a single color scale based on RVOL
-                // Using a green scale, as "in a squeeze" is a state of interest
-                const colorScale = d3.scaleLinear()
-                    .domain([0, 5]) // RVOL typically ranges from 0 to 5+
-                    .range(["#166534", "#22c55e"]) // Dark green to bright green
-                    .clamp(true);
 
                 // --- D3 Data Binding ---
                 const cells = chartContainer.selectAll(".cell")
                     .data(data, d => d.name);
 
-                // Exit selection
                 cells.exit().remove();
 
-                // Enter selection
                 const enterCells = cells.enter()
                     .append("div")
                     .attr("class", "cell")
                     .on("click", (event, d) => window.open(d.url, "_blank"))
                     .on("mouseover", function(event, d) {
                         tooltip.transition().duration(200).style("opacity", .9);
-                        tooltip.html(
-                            `<strong>${d.name.replace('NSE:', '')}</strong><br/>` +
-                            `Squeeze on ${d.count} timeframes<br/>` +
-                            `RVOL: ${d.rvol.toFixed(2)}<br/>` +
-                            `Score: ${d.value.toFixed(2)}`
-                        )
-                        .style("left", (event.pageX + 10) + "px")
-                        .style("top", (event.pageY - 28) + "px");
+                        tooltip.html(getTooltipHtml(d))
+                            .style("left", (event.pageX + 10) + "px")
+                            .style("top", (event.pageY - 28) + "px");
                     })
                     .on("mouseout", function(d) {
                         tooltip.transition().duration(500).style("opacity", 0);
@@ -124,32 +149,47 @@
                 enterCells.append("img").attr("class", "stock-logo");
                 enterCells.append("div").attr("class", "stock-ticker");
                 enterCells.append("div").attr("class", "stock-info");
- 
-                // Merge enter and update selections
+
                 const updateCells = enterCells.merge(cells);
- 
 
-                // Update all cells
-                updateCells.style("background-color", d => colorScale(d.rvol));
-
- 
-                updateCells.select(".stock-logo")
-                    .attr("src", d => d.logo)
-                    .style("display", d => d.logo ? 'block' : 'none');
-
+                updateCells.style("background-color", d => getCellColor(d));
+                updateCells.select(".stock-logo").attr("src", d => d.logo).style("display", d => d.logo ? 'block' : 'none');
                 updateCells.select(".stock-ticker").text(d => d.name.replace('NSE:', ''));
                 updateCells.select(".stock-info").text(d => `RVOL: ${d.rvol.toFixed(2)}`);
 
             } catch (error) {
-                console.error("Failed to load or process data:", error);
-                chartContainer.html("<p class='text-center text-red-500'>Failed to load data. Please check the console.</p>");
+                console.error(`Failed to load data from ${filename}:`, error);
+                chartContainer.html(`<p class='text-center text-red-500'>Could not load heatmap data. Is the Python scanner running?</p>`);
             }
- 
         }
 
-        // Initial data load and interval
-        loadData();
-        setInterval(loadData, 120000);
+        function setMode(mode) {
+            currentMode = mode;
+
+            if (mode === 'fired') {
+                btnFired.classList.add('bg-blue-600', 'text-white');
+                btnFired.classList.remove('bg-gray-700', 'text-gray-300');
+                btnInSqueeze.classList.add('bg-gray-700', 'text-gray-300');
+                btnInSqueeze.classList.remove('bg-blue-600', 'text-white');
+                description.innerText = 'Heatmap of stocks that have just broken out of a volatility squeeze.';
+            } else {
+                btnInSqueeze.classList.add('bg-blue-600', 'text-white');
+                btnInSqueeze.classList.remove('bg-gray-700', 'text-gray-300');
+                btnFired.classList.add('bg-gray-700', 'text-gray-300');
+                btnFired.classList.remove('bg-blue-600', 'text-white');
+                description.innerText = 'Heatmap of stocks that are currently in a state of low volatility.';
+            }
+            loadData();
+        }
+
+        btnFired.addEventListener('click', () => setMode('fired'));
+        btnInSqueeze.addEventListener('click', () => setMode('in_squeeze'));
+
+        // Initial setup
+        setMode('fired');
+        if (refreshInterval) clearInterval(refreshInterval);
+        refreshInterval = setInterval(loadData, 120000);
+
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Updated `BBSqueeze.py` to generate two separate JSON files: `treemap_data_in_squeeze.json` for stocks currently in a squeeze, and `treemap_data_fired.json` for stocks where a squeeze has recently fired.
- Modified the main query to fetch full data for 'in squeeze' stocks and process them accordingly.
- Enhanced `SqueezeHeatmap.html` with a UI toggle to allow users to switch between the two views.
- Refactored the JavaScript to load the appropriate data file based on the selected mode and apply different color scales and tooltips for each view.