### PR TITLE
feat: Create unified dashboard with advanced grouping

### DIFF
--- a/SqueezeHeatmap.html
+++ b/SqueezeHeatmap.html
@@ -8,57 +8,79 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         body { font-family: sans-serif; background-color: #111827; color: white; }
-        .timeframe-group {
-            margin-bottom: 24px;
-        }
-        .timeframe-title {
-            font-size: 1.25rem;
+        .section-title {
+            font-size: 1.5rem;
             font-weight: 700;
-            margin-bottom: 8px;
-            padding-bottom: 4px;
-            border-bottom: 2px solid #374151;
+            margin-bottom: 1rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 2px solid #4b5563;
         }
         .grid-container {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
-            gap: 8px;
+            grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+            gap: 6px;
+        }
+        .timeframe-group {
+            margin-bottom: 2rem;
+        }
+        .timeframe-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 0.75rem;
+            color: #9ca3af;
+        }
+        .momentum-columns {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.5rem;
+        }
+        .momentum-column h3 {
+            font-size: 1rem;
+            font-weight: 600;
+            text-align: center;
+            margin-bottom: 0.5rem;
         }
         .cell {
+            position: relative;
             display: flex;
             flex-direction: column;
-            justify-content: space-between;
+            justify-content: center;
             align-items: center;
-            padding: 10px;
+            padding: 8px;
             border-radius: 6px;
             cursor: pointer;
             text-align: center;
-            height: 110px;
+            height: 90px;
             transition: transform 0.2s, background-color 0.2s;
             border: 1px solid #374151;
-        }
-        .stock-logo {
-            width: 32px;
-            height: 32px;
-            margin-bottom: 5px;
         }
         .cell:hover {
             transform: scale(1.05);
             border-color: #9ca3af;
         }
         .stock-logo {
-            width: 36px;
-            height: 36px;
-            margin-bottom: 6px;
-            border-radius: 50%;
-            background-color: #374151;
+            width: 28px;
+            height: 28px;
+            margin-bottom: 4px;
         }
         .stock-ticker {
             font-weight: 600;
-            font-size: 14px;
+            font-size: 12px;
         }
         .stock-info {
-            font-size: 11px;
+            font-size: 10px;
             color: #d1d5db;
+        }
+        .squeeze-badge {
+            position: absolute;
+            top: 2px;
+            right: 2px;
+            background-color: rgba(0, 0, 0, 0.6);
+            color: white;
+            font-size: 9px;
+            font-weight: bold;
+            padding: 1px 4px;
+            border-radius: 4px;
         }
         .tooltip {
             position: absolute;
@@ -76,24 +98,27 @@
 </head>
 <body class="bg-gray-900">
     <div class="container mx-auto p-4">
-        <h1 class="text-3xl font-bold text-center mb-2">Real-Time Stock Squeeze Scanner</h1>
-        <div id="toggle-controls" class="flex justify-center my-4 space-x-2">
-            <button id="btn-fired" class="px-4 py-2 rounded-md text-sm font-medium transition">Squeeze Fired</button>
-            <button id="btn-in-squeeze" class="px-4 py-2 rounded-md text-sm font-medium transition">In Squeeze</button>
+        <h1 class="text-3xl font-bold text-center mb-6">Real-Time Stock Squeeze Dashboard</h1>
+
+        <!-- Squeeze Fired Section -->
+        <div class="mb-8">
+            <h2 class="section-title">Squeeze Fired</h2>
+            <div id="fired-container" class="grid-container"></div>
         </div>
-        <p id="description" class="text-center text-gray-400 mb-6"></p>
-        <div id="chart"></div>
+
+        <!-- In Squeeze Section -->
+        <div>
+            <h2 class="section-title">In Squeeze</h2>
+            <div id="in-squeeze-container"></div>
+        </div>
+
         <div class="tooltip"></div>
     </div>
 
     <script>
-        const chartContainer = d3.select("#chart");
+        const firedContainer = d3.select("#fired-container");
+        const inSqueezeContainer = d3.select("#in-squeeze-container");
         const tooltip = d3.select(".tooltip");
-        const btnFired = document.getElementById('btn-fired');
-        const btnInSqueeze = document.getElementById('btn-in-squeeze');
-        const description = document.getElementById('description');
-
-        let currentMode = 'fired'; // 'fired' or 'in_squeeze'
         let refreshInterval;
 
         // --- Color Scales ---
@@ -108,109 +133,92 @@
             return neutralColor(d.rvol);
         }
 
-        function getTooltipHtml(d) {
+        function getTooltipHtml(d, type) {
             const momentumHtml = `Momentum: <span style="color: ${getCellColor(d)};">${d.momentum}</span><br/>`;
-            const squeezeHtml = currentMode === 'in_squeeze' ? `Squeeze on ${d.count} timeframes (${d.highest_tf})<br/>` : '';
-
-            return `<strong>${d.name.replace('NSE:', '')}</strong><br/>` +
-                   squeezeHtml +
-                   momentumHtml +
-                   `RVOL: ${d.rvol.toFixed(2)}<br/>` +
-                   `Score: ${d.value.toFixed(2)}`;
+            const squeezeHtml = type === 'in_squeeze' ? `Squeeze on ${d.count} TFs (${d.highest_tf})<br/>` : '';
+            return `<strong>${d.name.replace('NSE:', '')}</strong><br/>` + squeezeHtml + momentumHtml + `RVOL: ${d.rvol.toFixed(2)}`;
         }
 
-        function renderCells(selection) {
-             // Enter selection
-            const enterCells = selection.enter()
-                .append("div")
-                .attr("class", "cell")
+        function renderCells(selection, type) {
+            const enterCells = selection.enter().append("div").attr("class", "cell")
                 .on("click", (event, d) => window.open(d.url, "_blank"))
                 .on("mouseover", function(event, d) {
                     tooltip.transition().duration(200).style("opacity", .9);
-                    tooltip.html(getTooltipHtml(d))
-                        .style("left", (event.pageX + 10) + "px")
-                        .style("top", (event.pageY - 28) + "px");
+                    tooltip.html(getTooltipHtml(d, type)).style("left", (event.pageX + 10) + "px").style("top", (event.pageY - 28) + "px");
                 })
-                .on("mouseout", function(d) {
-                    tooltip.transition().duration(500).style("opacity", 0);
-                });
+                .on("mouseout", () => tooltip.transition().duration(500).style("opacity", 0));
 
+            if (type === 'in_squeeze') {
+                enterCells.append("div").attr("class", "squeeze-badge").text(d => d.count);
+            }
             enterCells.append("img").attr("class", "stock-logo");
             enterCells.append("div").attr("class", "stock-ticker");
             enterCells.append("div").attr("class", "stock-info");
 
-            // Merge enter and update selections
             const updateCells = enterCells.merge(selection);
-
-            // Update all cells
             updateCells.style("background-color", d => getCellColor(d));
             updateCells.select(".stock-logo").attr("src", d => d.logo).style("display", d => d.logo ? 'block' : 'none');
             updateCells.select(".stock-ticker").text(d => d.name.replace('NSE:', ''));
             updateCells.select(".stock-info").text(d => `RVOL: ${d.rvol.toFixed(2)}`);
         }
 
+        function renderFired(data) {
+            firedContainer.html(data.length === 0 ? "<p class='text-gray-400'>No squeezes have fired recently.</p>" : "");
+            const cells = firedContainer.selectAll(".cell").data(data, d => d.name);
+            cells.exit().remove();
+            renderCells(cells, 'fired');
+        }
+
+        function renderInSqueeze(data) {
+            inSqueezeContainer.html(data.length === 0 ? "<p class='text-gray-400'>No stocks are currently in a squeeze.</p>" : "");
+            const tfOrder = ['Monthly', 'Weekly', '4H', '2H', '1H', '30m', '15m', '5m', '1m', 'Daily', 'Unknown'];
+            const groupedData = d3.group(data, d => d.highest_tf);
+            const sortedGroups = Array.from(groupedData.entries()).sort((a, b) => tfOrder.indexOf(a[0]) - tfOrder.indexOf(b[0]));
+
+            const groups = inSqueezeContainer.selectAll('.timeframe-group').data(sortedGroups, d => d[0]);
+            groups.exit().remove();
+
+            const enterGroups = groups.enter().append('div').attr('class', 'timeframe-group');
+            enterGroups.append('h2').attr('class', 'timeframe-title');
+            const momentumCols = enterGroups.append('div').attr('class', 'momentum-columns');
+            momentumCols.append('div').attr('class', 'bullish-col').html("<h3 class='text-green-400'>Bullish</h3><div class='grid-container'></div>");
+            momentumCols.append('div').attr('class', 'bearish-col').html("<h3 class='text-red-400'>Bearish</h3><div class='grid-container'></div>");
+
+            const updateGroups = enterGroups.merge(groups);
+            updateGroups.select('.timeframe-title').text(d => d[0]);
+
+            updateGroups.each(function([tf, stocks]) {
+                const bullishStocks = stocks.filter(s => s.momentum === 'Bullish').sort((a,b) => b.value - a.value);
+                const bearishStocks = stocks.filter(s => s.momentum === 'Bearish').sort((a,b) => b.value - a.value);
+
+                const bullishCells = d3.select(this).select('.bullish-col .grid-container').selectAll('.cell').data(bullishStocks, d => d.name);
+                bullishCells.exit().remove();
+                renderCells(bullishCells, 'in_squeeze');
+
+                const bearishCells = d3.select(this).select('.bearish-col .grid-container').selectAll('.cell').data(bearishStocks, d => d.name);
+                bearishCells.exit().remove();
+                renderCells(bearishCells, 'in_squeeze');
+            });
+        }
+
         async function loadData() {
-            const filename = currentMode === 'fired' ? 'treemap_data_fired.json' : 'treemap_data_in_squeeze.json';
             try {
-                const data = await d3.json(`${filename}?t=${new Date().getTime()}`);
-                data.sort((a, b) => b.value - a.value);
-
-                chartContainer.html(''); // Clear previous content
-
-                if (currentMode === 'in_squeeze') {
-                    const tfOrder = ['Monthly', 'Weekly', '4H', '2H', '1H', '30m', '15m', '5m', '1m', 'Daily', 'Unknown'];
-                    const groupedData = d3.group(data, d => d.highest_tf);
-                    const sortedGroups = Array.from(groupedData.entries()).sort((a, b) => tfOrder.indexOf(a[0]) - tfOrder.indexOf(b[0]));
-
-                    sortedGroups.forEach(([tf, stocks]) => {
-                        const group = chartContainer.append('div').attr('class', 'timeframe-group');
-                        group.append('h2').attr('class', 'timeframe-title').text(tf);
-                        const grid = group.append('div').attr('class', 'grid-container');
-                        const cells = grid.selectAll('.cell').data(stocks, d => d.name);
-                        cells.exit().remove();
-                        renderCells(cells);
-                    });
-
-                } else { // Fired mode
-                    chartContainer.attr('class', 'grid-container');
-                    const cells = chartContainer.selectAll('.cell').data(data, d => d.name);
-                    cells.exit().remove();
-                    renderCells(cells);
-                }
-
+                const [firedData, inSqueezeData] = await Promise.all([
+                    d3.json(`treemap_data_fired.json?t=${new Date().getTime()}`),
+                    d3.json(`treemap_data_in_squeeze.json?t=${new Date().getTime()}`)
+                ]);
+                renderFired(firedData.sort((a, b) => b.value - a.value));
+                renderInSqueeze(inSqueezeData);
             } catch (error) {
-                console.error(`Failed to load data from ${filename}:`, error);
-                chartContainer.html(`<p class='text-center text-red-500'>Could not load heatmap data. Is the Python scanner running?</p>`);
+                console.error("Failed to load data:", error);
+                firedContainer.html("<p class='text-center text-red-500'>Could not load 'Fired' data.</p>");
+                inSqueezeContainer.html("<p class='text-center text-red-500'>Could not load 'In Squeeze' data.</p>");
             }
         }
 
-        function setMode(mode) {
-            currentMode = mode;
-
-            if (mode === 'fired') {
-                btnFired.classList.add('bg-blue-600', 'text-white');
-                btnFired.classList.remove('bg-gray-700', 'text-gray-300');
-                btnInSqueeze.classList.add('bg-gray-700', 'text-gray-300');
-                btnInSqueeze.classList.remove('bg-blue-600', 'text-white');
-                description.innerText = 'Heatmap of stocks that have just broken out of a volatility squeeze.';
-            } else {
-                btnInSqueeze.classList.add('bg-blue-600', 'text-white');
-                btnInSqueeze.classList.remove('bg-gray-700', 'text-gray-300');
-                btnFired.classList.add('bg-gray-700', 'text-gray-300');
-                btnFired.classList.remove('bg-blue-600', 'text-white');
-                description.innerText = 'Heatmap of stocks that are currently in a state of low volatility, grouped by the highest timeframe in a squeeze.';
-            }
-            loadData();
-        }
-
-        btnFired.addEventListener('click', () => setMode('fired'));
-        btnInSqueeze.addEventListener('click', () => setMode('in_squeeze'));
-
-        // Initial setup
-        setMode('fired');
-        if (refreshInterval) clearInterval(refreshInterval);
+        // Initial data load and interval
+        loadData();
         refreshInterval = setInterval(loadData, 120000);
-
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Reworked `SqueezeHeatmap.html` to display 'Squeeze Fired' and 'In Squeeze' stocks on a single page, removing the toggle.
- Implemented advanced grouping for the 'In Squeeze' section, organizing stocks by highest timeframe and then into 'Bullish'/'Bearish' columns.
- Optimized the layout with smaller cells for a more compact and data-rich view.
- Added a squeeze count badge to each 'In Squeeze' cell for at-a-glance information.