### PR TITLE
Fix: Correctly build filter query for TradingView API

### DIFF
--- a/BBSqueeze.py
+++ b/BBSqueeze.py
@@ -293,7 +293,7 @@ while True:
             col('Value.Traded|5') > 10000000,
             Or(*squeeze_conditions)
         ]
-        query_in_squeeze = Query().select(*select_cols).where(*filters).set_markets('india')
+        query_in_squeeze = Query().select(*select_cols).where2(And(*filters)).set_markets('india')
         _, df_in_squeeze = query_in_squeeze.get_scanner_data()
 
         current_squeeze_pairs = []


### PR DESCRIPTION
The script was failing with a `400 Bad Request` error due to a malformed JSON payload sent to the TradingView scanner API. The `tradingview_screener` library's `where()` method was being used incorrectly with a complex `Or()` condition.

This change replaces the `.where()` method with `.where2(And(*filters))` to ensure the filter query is constructed with the correct structure that the API expects, resolving the JSON parse error.