### PR TITLE
Refactor: Unify HTML layouts to a compact, time-grouped design

### DIFF
--- a/CompactHeatmap.html
+++ b/CompactHeatmap.html
@@ -38,23 +38,24 @@
              background-color: #374151; /* gray-700 */
              color: #d1d5db; /* gray-300 */
         }
+        .timeframe-box {
+            background-color: #1f2937; /* gray-800 */
+            border-radius: 8px;
+            padding: 1rem;
+            border: 1px solid #374151; /* gray-700 */
+        }
         .grid-container {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
             gap: 6px;
         }
-        .timeframe-group {
-            margin-bottom: 2rem;
-        }
         .timeframe-title {
-            font-size: 1.1rem;
-            font-weight: 600;
-            margin-bottom: 0.75rem;
-            color: #9ca3af;
-            cursor: pointer;
-            display: flex;
-            align-items: center;
-            user-select: none;
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid #4b5563;
+            color: #d1d5db;
         }
         .timeframe-title .arrow {
             margin-right: 8px;
@@ -145,7 +146,7 @@
             <button data-strength="VERY STRONG" class="filter-btn px-3 py-1 rounded-md text-sm font-medium transition">VERY STRONG</button>
         </div>
 
-        <div id="heatmap-container" class="grid-container"></div>
+        <div id="heatmap-container" class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6"></div>
         <div class="tooltip"></div>
     </div>
 
@@ -177,27 +178,51 @@
         }
 
         function renderHeatmap(data) {
-            heatmapContainer.html(data.length === 0 ? "<p class='text-center text-gray-400'>No stocks match the current filter.</p>" : "");
+            if (data.length === 0) {
+                heatmapContainer.html("<p class='col-span-full text-gray-400 text-center py-4'>No stocks match the current filter.</p>");
+                return;
+            } else {
+                 heatmapContainer.html("");
+            }
 
-            const cells = heatmapContainer.selectAll('.cell').data(data, d => d.name);
-            cells.exit().remove();
+            const tfOrder = ['Monthly', 'Weekly', '4H', '2H', '1H', '30m', '15m', '5m', '1m', 'Daily', 'Unknown'];
+            const groupedData = d3.group(data, d => d.highest_tf);
+            const sortedGroups = Array.from(groupedData.entries()).sort((a, b) => tfOrder.indexOf(a[0]) - tfOrder.indexOf(b[0]));
 
-            const enterCells = cells.enter().append("div").attr("class", "cell")
-                .on("click", (event, d) => window.open(d.url, "_blank"))
-                .on("mouseover", function(event, d) {
-                    tooltip.transition().duration(200).style("opacity", .9);
-                    tooltip.html(getTooltipHtml(d)).style("left", (event.pageX + 10) + "px").style("top", (event.pageY - 28) + "px");
-                })
-                .on("mouseout", () => tooltip.transition().duration(500).style("opacity", 0));
+            const groups = heatmapContainer.selectAll('.timeframe-box').data(sortedGroups, d => d[0]);
+            groups.exit().remove();
 
-            enterCells.append("div").attr("class", "squeeze-badge").text(d => d.count);
-            enterCells.append("img").attr("class", "stock-logo");
-            enterCells.append("div").attr("class", "stock-ticker");
+            const enterGroups = groups.enter().append('div').attr('class', 'timeframe-box');
+            enterGroups.append('h2').attr('class', 'timeframe-title').text(d => d[0]);
+            enterGroups.append('div').attr('class', 'grid-container');
 
-            const updateCells = enterCells.merge(cells);
-            updateCells.style("background-color", d => getCellColor(d));
-            updateCells.select(".stock-logo").attr("src", d => d.logo).style("display", d => d.logo ? 'block' : 'none');
-            updateCells.select(".stock-ticker").text(d => d.name.replace('NSE:', ''));
+            const updateGroups = enterGroups.merge(groups);
+            updateGroups.select('h2').text(d => d[0]);
+
+            updateGroups.each(function([tf, stocks]) {
+                const sortedStocks = stocks.sort((a,b) => b.value - a.value);
+                const cells = d3.select(this).select('.grid-container').selectAll('.cell').data(sortedStocks, d => d.name);
+                cells.exit().remove();
+
+                const enterCells = cells.enter().append("div").attr("class", "cell")
+                    .on("click", (event, d) => window.open(d.url, "_blank"))
+                    .on("mouseover", function(event, d) {
+                        tooltip.transition().duration(200).style("opacity", .9);
+                        tooltip.html(getTooltipHtml(d)).style("left", (event.pageX + 10) + "px").style("top", (event.pageY - 28) + "px");
+                    })
+                    .on("mouseout", () => tooltip.transition().duration(500).style("opacity", 0));
+
+                enterCells.append("div").attr("class", "squeeze-badge").text(d => d.count);
+                enterCells.append("img").attr("class", "stock-logo");
+                enterCells.append("div").attr("class", "stock-ticker");
+                enterCells.append("div").attr("class", "stock-info");
+
+                const updateCells = enterCells.merge(cells);
+                updateCells.style("background-color", d => getCellColor(d));
+                updateCells.select(".stock-logo").attr("src", d => d.logo).style("display", d => d.logo ? 'block' : 'none');
+                updateCells.select(".stock-ticker").text(d => d.name.replace('NSE:', ''));
+                updateCells.select(".stock-info").text(d => `RVOL: ${d.rvol.toFixed(2)}`);
+            });
         }
 
         function applyFiltersAndRender() {
@@ -212,15 +237,6 @@
                     filteredData = fullInSqueezeData.filter(d => activeLevels.includes(d.squeeze_strength));
                 }
             }
-
-            const tfOrder = ['Monthly', 'Weekly', '4H', '2H', '1H', '30m', '15m', '5m', '1m', 'Daily', 'Unknown'];
-            filteredData.sort((a, b) => {
-                const tfIndexA = tfOrder.indexOf(a.highest_tf);
-                const tfIndexB = tfOrder.indexOf(b.highest_tf);
-                if (tfIndexA !== tfIndexB) return tfIndexA - tfIndexB;
-                return b.count - a.count;
-            });
-
             renderHeatmap(filteredData);
         }
 

--- a/Fired.html
+++ b/Fired.html
@@ -11,17 +11,24 @@
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
         body { font-family: sans-serif; background-color: #111827; color: white; }
+        .timeframe-box {
+            background-color: #1f2937; /* gray-800 */
+            border-radius: 8px;
+            padding: 1rem;
+            border: 1px solid #374151; /* gray-700 */
+        }
         .grid-container {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(90px, 1fr));
+            grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
             gap: 6px;
         }
-        .timeframe-group { margin-bottom: 2rem; }
         .timeframe-title {
-            font-size: 1.1rem;
-            font-weight: 600;
-            margin-bottom: 0.75rem;
-            color: #9ca3af;
+            font-size: 1.25rem;
+            font-weight: 700;
+            margin-bottom: 1rem;
+            padding-bottom: 0.5rem;
+            border-bottom: 1px solid #4b5563;
+            color: #d1d5db;
         }
         .cell {
             position: relative;
@@ -70,7 +77,7 @@
             </nav>
         </header>
 
-        <div id="fired-container">
+        <div id="fired-container" class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
             <!-- Fired squeezes will be dynamically inserted here as a heatmap -->
         </div>
         <div class="tooltip"></div>
@@ -121,16 +128,21 @@
         }
 
         function renderFiredHeatmap(data) {
-            firedContainer.html(data.length === 0 ? "<p class='text-gray-400 text-center py-8'>No squeezes have fired with increased volatility recently.</p>" : "");
+            if (data.length === 0) {
+                firedContainer.html("<p class='col-span-full text-gray-400 text-center py-8'>No squeezes have fired with increased volatility recently.</p>");
+                return;
+            } else {
+                firedContainer.html("");
+            }
 
             const tfOrder = ['Monthly', 'Weekly', '4H', '2H', '1H', '30m', '15m', '5m', '1m', 'Daily'];
             const groupedData = d3.group(data, d => d.fired_timeframe);
             const sortedGroups = Array.from(groupedData.entries()).sort((a, b) => tfOrder.indexOf(a[0]) - tfOrder.indexOf(b[0]));
 
-            const groups = firedContainer.selectAll('.timeframe-group').data(sortedGroups, d => d[0]);
+            const groups = firedContainer.selectAll('.timeframe-box').data(sortedGroups, d => d[0]);
             groups.exit().remove();
 
-            const enterGroups = groups.enter().append('div').attr('class', 'timeframe-group');
+            const enterGroups = groups.enter().append('div').attr('class', 'timeframe-box');
             enterGroups.append('h2').attr('class', 'timeframe-title').text(d => `Fired on ${d[0]}`);
             enterGroups.append('div').attr('class', 'grid-container');
 

--- a/SqueezeHeatmap.html
+++ b/SqueezeHeatmap.html
@@ -158,7 +158,9 @@
         <!-- In Squeeze Section -->
         <div id="in-squeeze-section-wrapper">
             <h2 class="section-title"><span class="arrow">&#9662;</span>In Squeeze</h2>
-            <div id="in-squeeze-container"></div>
+            <div id="in-squeeze-container" class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
+                <!-- Timeframe boxes will be dynamically inserted here -->
+            </div>
         </div>
 
         <div class="tooltip"></div>
@@ -246,7 +248,7 @@
             updateGroups.select('h2').text(d => `Fired on ${d[0]}`);
 
             updateGroups.each(function([tf, stocks]) {
-                const sortedStocks = stocks.sort((a,b) => b.HeatmapScore - a.HeatmapScore);
+                const sortedStocks = stocks.sort((a,b) => b.value - a.value);
                 const cells = d3.select(this).select('.grid-container').selectAll('.cell').data(sortedStocks, d => `${d.name}-${d.fired_timeframe}`);
                 cells.exit().remove();
                 renderCells(cells, 'fired');
@@ -254,52 +256,32 @@
         }
 
         function renderInSqueeze(data) {
-            inSqueezeContainer.html(data.length === 0 ? "<p class='text-gray-400'>No stocks match the current filter.</p>" : "");
+            if (data.length === 0) {
+                inSqueezeContainer.html("<p class='col-span-full text-gray-400 text-center py-4'>No stocks match the current filter.</p>");
+                return;
+            } else {
+                 inSqueezeContainer.html("");
+            }
+
             const tfOrder = ['Monthly', 'Weekly', '4H', '2H', '1H', '30m', '15m', '5m', '1m', 'Daily', 'Unknown'];
             const groupedData = d3.group(data, d => d.highest_tf);
             const sortedGroups = Array.from(groupedData.entries()).sort((a, b) => tfOrder.indexOf(a[0]) - tfOrder.indexOf(b[0]));
 
-            const groups = inSqueezeContainer.selectAll('.timeframe-group').data(sortedGroups, d => d[0]);
+            const groups = inSqueezeContainer.selectAll('.timeframe-box').data(sortedGroups, d => d[0]);
             groups.exit().remove();
 
-            const enterGroups = groups.enter().append('div').attr('class', 'timeframe-group');
-
-            const title = enterGroups.append('h2').attr('class', 'timeframe-title');
-            title.append('span').attr('class', 'arrow').html('&#9662;');
-            title.append('span').text(d => d[0]);
-
-            const momentumCols = enterGroups.append('div').attr('class', 'momentum-columns');
-            momentumCols.append('div').attr('class', 'bullish-col').html("<div class='grid-container'></div>");
-            momentumCols.append('div').attr('class', 'bearish-col').html("<div class='grid-container'></div>");
+            const enterGroups = groups.enter().append('div').attr('class', 'timeframe-box');
+            enterGroups.append('h2').attr('class', 'timeframe-title').text(d => d[0]);
+            enterGroups.append('div').attr('class', 'grid-container');
 
             const updateGroups = enterGroups.merge(groups);
-            updateGroups.select('.timeframe-title span:last-child').text(d => d[0]);
-
-            updateGroups.select('.timeframe-title').on('click', function() {
-                const group = d3.select(this.parentNode);
-                const momentumColumns = group.select('.momentum-columns');
-                const isCollapsed = momentumColumns.style('display') === 'none';
-                momentumColumns.style('display', isCollapsed ? 'flex' : 'none');
-                d3.select(this).classed('collapsed', !isCollapsed);
-            });
+            updateGroups.select('h2').text(d => d[0]);
 
             updateGroups.each(function([tf, stocks]) {
-                const bullishStocks = stocks.filter(s => s.momentum === 'Bullish').sort((a,b) => b.value - a.value);
-                const bearishStocks = stocks.filter(s => s.momentum === 'Bearish').sort((a,b) => b.value - a.value);
-
-                const bullishColEl = d3.select(this).select('.bullish-col');
-                const bearishColEl = d3.select(this).select('.bearish-col');
-
-                bullishColEl.style('display', bullishStocks.length > 0 ? null : 'none');
-                bearishColEl.style('display', bearishStocks.length > 0 ? null : 'none');
-
-                const bullishCells = bullishColEl.select('.grid-container').selectAll('.cell').data(bullishStocks, d => d.name);
-                bullishCells.exit().remove();
-                renderCells(bullishCells, 'in_squeeze');
-
-                const bearishCells = bearishColEl.select('.grid-container').selectAll('.cell').data(bearishStocks, d => d.name);
-                bearishCells.exit().remove();
-                renderCells(bearishCells, 'in_squeeze');
+                const sortedStocks = stocks.sort((a,b) => b.value - a.value);
+                const cells = d3.select(this).select('.grid-container').selectAll('.cell').data(sortedStocks, d => d.name);
+                cells.exit().remove();
+                renderCells(cells, 'in_squeeze');
             });
         }
 


### PR DESCRIPTION
This change refactors the HTML pages to use a consistent, compact layout. All pages now group stocks by timeframe into styled boxes, providing a unified user experience.

- The "In Squeeze" section of `SqueezeHeatmap.html` and the `CompactHeatmap.html` page now group stocks by their highest timeframe.
- The previous two-column "Bullish/Bearish" layout has been replaced with a single-grid layout as requested.
- The CSS and JavaScript have been updated across all pages to support the new layout and ensure consistent styling and sorting logic.